### PR TITLE
Use class name as detail if exception message is not set

### DIFF
--- a/src/ApiProblem/ApiProblem.php
+++ b/src/ApiProblem/ApiProblem.php
@@ -135,7 +135,9 @@ class ApiProblem
             $type = self::RFC2616;
         }
 
-        return new self($code, $exception->getMessage(), $title, $type, $additionalDetails);
+        $detail = empty($exception->getMessage()) ? get_class($exception) : $exception->getMessage();
+
+        return new self($code, $detail, $title, $type, $additionalDetails);
     }
 
     /**


### PR DESCRIPTION
Exception message isn't mandatory and if isn't set the exception is thrown. In many cases the exception class name is self explained, so if message is not set use the class name instead.
